### PR TITLE
Make 2-stage Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,25 @@ statefulstore.cloudstate.io/shopping-store created
 ```
 
 ### Shopping Cart Service
+
 ```
 cd ../shopping-cart
+```
+
+#### Installing development dependencies (optional)
+
+Although this is not required for building and deploying the service, you might want to set up development environment
+```
 nvm install
 nvm use
 npm install
-npm run prestart
 ```
-For this service there is no web front end, so we only need to compile the `shoppingcart.proto` into the `user-function.desc`.
+After that you can run tests
+```
+npm test
+```
+
+#### Building a container image
 
 Build a docker image with the right registry and tag
 
@@ -106,6 +117,8 @@ Push the docker image to the registry
 ```
 docker push <my-registry>/shopping-cart:latest
 ```
+
+#### Deploying the service
 
 Deploy the image by changing into the deploy folder and editing `shopping-cart.yaml` to point to the docker image that you just pushed.
 ```

--- a/shopping-cart/.dockerignore
+++ b/shopping-cart/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+node_modules
+user-function.desc

--- a/shopping-cart/.dockerignore
+++ b/shopping-cart/.dockerignore
@@ -1,4 +1,2 @@
-Dockerfile
-.dockerignore
 node_modules
 user-function.desc

--- a/shopping-cart/Dockerfile
+++ b/shopping-cart/Dockerfile
@@ -1,15 +1,34 @@
-FROM node:12.16.3-buster-slim
-# Copy and install deps. This is done as a separate step as an optimization, so changes to the programs files
-# don't require the npm install to be redone
-RUN mkdir -p /opt/samples/js-shopping-cart
-RUN mkdir -p /opt/samples/js-shopping-cart/protocols/example
-#COPY node-support /opt/node-support
-COPY package.json /opt/samples/js-shopping-cart/
-RUN cd /opt/samples/js-shopping-cart && npm install
-# Now copy the entire app
-COPY . /opt/samples/js-shopping-cart
-WORKDIR /opt/samples/js-shopping-cart
-#RUN npm run prestart  # CA - TODO: this is giving a proto problem (will circle back to deal)
-# run
+FROM node:12.18.0-buster AS builder
+
+# Run as an unprivileged user
+WORKDIR /home/node
+USER node
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Build app
+COPY . .
+RUN npm run build
+
+# Remove dev packages
+RUN npm prune --production
+
+# Create production image
+FROM node:12.18.0-buster-slim
+
+# Run as an unprivileged user
+WORKDIR /home/node
+USER node
+
+# Install app
+COPY package*.json ./
+COPY *.js ./
+COPY *.proto ./
+COPY --from=builder /home/node/node_modules node_modules/
+COPY --from=builder /home/node/user-function.desc .
+
+# Run
 EXPOSE 8080
-CMD ["npm", "run", "start-no-prestart"]
+CMD ["npm", "start"]

--- a/shopping-cart/package.json
+++ b/shopping-cart/package.json
@@ -39,10 +39,9 @@
   },
   "scripts": {
     "test": "mocha",
-    "prestart": "compile-descriptor ./shoppingcart.proto",
     "pretest": "compile-descriptor ./shoppingcart.proto",
+    "build": "compile-descriptor ./shoppingcart.proto",
     "start": "node index.js",
-    "start-no-prestart": "node index.js",
     "dockerbuild": "docker build -f ./Dockerfile -t ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest ../..",
     "dockerpush": "docker push ${DOCKER_PUBLISH_TO:-cloudstateio}/js-shopping-cart:latest",
     "dockerbuildpush": "npm run dockerbuild && npm run dockerpush"


### PR DESCRIPTION
Highlights:
- Build steps are performed at `builder` stage. At the moment that is only generating `user-function.desc`. Then a small production image is created at stage 2.
- Only production `node_modules` are copied to the production image. That reduced image size from 337MB to 233MB.
- `npm` is no longer required to be installed for building an image. The only requirement is having Docker installed.