### PR TITLE
Append -js to container image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Alternatively, you can clone the [cloudstateio/samples-ui-shoppingcart](https://
 
 ### Shopping cart service
 
-You can use the pre-built `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart:latest` container image available at Lightbend Cloudstate samples repository.
+You can use the pre-built `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-js:latest` container image available at Lightbend Cloudstate samples repository.
 
 Alternatively, you can build an image from the sources in the `shopping-cart` directory and push it to your own container image repository.
 
@@ -103,13 +103,13 @@ Proceed when `STATUS` is `ready`, this can take some time.
 
 ### Deploying the shopping cart service
 
-A pre-build container image of the frontend service is provided as `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart`.
+A pre-build container image of the shopping cart service is provided as `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-js`.
 If you have built your own container image, change the image in the following command to point to the one that you just pushed.
 
 ```shell
 $ csctl svc deploy \
     shopping-cart \
-    lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart \
+    lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-js \
     --with-store shopping-store
 ```
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -49,7 +49,7 @@ metadata:
   name: frontend
 spec:
   containers:
-  - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart:latest # <-- Change this to your repo/image
+  - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-js:latest # <-- Change this to your repo/image
     name: frontend
 ```
 

--- a/deploy/shopping-cart.yaml
+++ b/deploy/shopping-cart.yaml
@@ -11,5 +11,5 @@ spec:
       # Name of a deployed Datastore to use.
       name: shopping-store
   containers:
-    - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart:latest
+    - image: lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-js:latest
       name: shopping-cart


### PR DESCRIPTION
Change the container image name to `lightbend-docker-registry.bintray.io/cloudstate-samples/shopping-cart-js` to distinguish it from other shopping cart samples.